### PR TITLE
[feat] Model reading supports list and dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ for instance in instances_csv:
     print(instance)
 ```
 
+## Test
+
+A local test environment is required. See the [contribution guide](https://resoto.com/docs/contributing/components) for instructions.
+
+The tests expect a ResotoCore on localhost with the default PSK `changeme`.
+You can start it locally via: `resotocore --graphdb-database resotoclient_test --psk changeme`
+
+To run the tests, run: `nox`.
+
+
+```bash 
+
 For more examples see the examples directory.
 
 ## Publish

--- a/README.md
+++ b/README.md
@@ -21,15 +21,21 @@ for instance in instances_csv:
 
 ## Test
 
-A local test environment is required. See the [contribution guide](https://resoto.com/docs/contributing/components) for instructions.
 
 The tests expect a ResotoCore on localhost with the default PSK `changeme`.
-You can start it locally via: `resotocore --graphdb-database resotoclient_test --psk changeme`
+You can start it locally via:
 
-To run the tests, run: `nox`.
+```bash
+$> resotocore --graphdb-database resotoclient_test --psk changeme
+```
 
+A local test environment is required. See the [contribution guide](https://resoto.com/docs/contributing/components) for instructions.
+When the virtual environment is available, use those commands to set up the project and run the tests:
 
-```bash 
+```bash
+$> pip install --upgrade pip poetry nox nox-poetry
+$> nox
+```
 
 For more examples see the examples directory.
 


### PR DESCRIPTION
# Description

ResotoCore `GET /model` defined to return an array, but returned a json object.
This change makes the client tolerant for different versions of ResotoClient.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Lint with `nox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
