### PR TITLE
Add data() function for /system/data endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "resotoclient"
-version = "1.1.0"
+version = "1.1.1"
 description = "Resoto Python client library"
 authors = ["Some Engineering Inc."]
 license = "Apache-2.0"

--- a/resotoclient/async_client.py
+++ b/resotoclient/async_client.py
@@ -621,6 +621,10 @@ class ResotoClient:
         else:
             raise AttributeError(await response.text())
 
+    async def data(self) -> Optional[JsObject]:
+        response = await self._get(f"/system/data")
+        return await response.json() if response.status_code == 200 else None
+
 
 def rnd_str(str_len: int = 10) -> str:
     return "".join(


### PR DESCRIPTION
# Description

Adds the `data()` function for the /system/data endpoint.
Maybe this should be `system_data()`? But then it's also just `ping()`  and `ready()` not `system_ping()`...


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
